### PR TITLE
Add Mac Chrome automation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # tmp_test_openai_comp_use
+
+## scroll_browser.py
+
+This script opens Google Chrome on macOS at
+`https://www.tglauner.com/mastering_interest_rate_derivatives` and scrolls down
+and up twice. It uses `pyautogui`, so ensure you have it installed and have given
+accessibility permissions on macOS.
+
+### Usage
+
+```bash
+pip install pyautogui
+python scroll_browser.py
+```

--- a/scroll_browser.py
+++ b/scroll_browser.py
@@ -1,0 +1,21 @@
+import time
+import subprocess
+import pyautogui
+
+URL = "https://www.tglauner.com/mastering_interest_rate_derivatives"
+
+# open Google Chrome with the URL
+subprocess.run(["open", "-a", "Google Chrome", URL])
+
+# wait for the browser to load
+print("Waiting for page to load...")
+time.sleep(5)
+
+# scroll down and up twice
+for _ in range(2):
+    pyautogui.scroll(-800)  # scroll down
+    time.sleep(1)
+    pyautogui.scroll(800)   # scroll up
+    time.sleep(1)
+
+print("Done scrolling.")


### PR DESCRIPTION
## Summary
- add `scroll_browser.py` to open Chrome and scroll a page
- document how to use the script in `README.md`

## Testing
- `python -m py_compile scroll_browser.py`

------
https://chatgpt.com/codex/tasks/task_e_684a3c7e278883228dfc8dee8e25d620